### PR TITLE
Support for pre- and post-traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ traverse(schema, cb);
 // 3. {type: 'integer'}
 ```
 
-Callback function is called for each schema object (not including draft-06 boolean schemas), including the root schema. Schema references ($ref) are not resolved, they are passed as is.
+Callback function is called for each schema object (not including draft-06 boolean schemas), including the root schema, in pre-order traversal. Schema references ($ref) are not resolved, they are passed as is.  Alternatively, you can call `traverse(schema, {pre, post}`, and
+then `pre` will be called before traversing child elements, and `post` will be called
+after all child elements have been traversed.
 
 Callback is passed these parameters:
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,28 @@ const schema = {
   }
 };
 
-traverse(schema, cb);
+traverse(schema, {cb});
 // cb is called 3 times with:
 // 1. root schema
 // 2. {type: 'string'}
 // 3. {type: 'integer'}
+
+// Or:
+
+traverse(schema, {cb: {pre, post}});
+// pre is called 3 times with:
+// 1. root schema
+// 2. {type: 'string'}
+// 3. {type: 'integer'}
+//
+// post is called 3 times with:
+// 1. {type: 'string'}
+// 2. {type: 'integer'}
+// 3. root schema
+
 ```
 
-Callback function is called for each schema object (not including draft-06 boolean schemas), including the root schema, in pre-order traversal. Schema references ($ref) are not resolved, they are passed as is.  Alternatively, you can call `traverse(schema, {pre, post}`, and
-then `pre` will be called before traversing child elements, and `post` will be called
-after all child elements have been traversed.
+Callback function `cb` is called for each schema object (not including draft-06 boolean schemas), including the root schema, in pre-order traversal. Schema references ($ref) are not resolved, they are passed as is.  Alternatively, you can pass a `{pre, post}` object as `cb`, and then `pre` will be called before traversing child elements, and `post` will be called after all child elements have been traversed.
 
 Callback is passed these parameters:
 
@@ -57,7 +69,7 @@ const schema = {
   }
 };
 
-traverse(schema, {allKeys: true}, cb);
+traverse(schema, {allKeys: true, cb});
 // cb is called 2 times with:
 // 1. root schema
 // 2. mySchema

--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 'use strict';
 
 var traverse = module.exports = function (schema, opts, cb) {
+  // Legacy support for v0.3.1 and earlier.
   if (typeof opts == 'function') {
     cb = opts;
     opts = {};
   }
-  _traverse(opts, cb, schema, '', schema);
+
+  var pre = opts.pre || cb || function() {};
+  var post = opts.post || function() {};
+
+  _traverse(opts, pre, post, schema, '', schema);
 };
 
 
@@ -53,25 +58,26 @@ traverse.skipKeywords = {
 };
 
 
-function _traverse(opts, cb, schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex) {
+function _traverse(opts, pre, post, schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex) {
   if (schema && typeof schema == 'object' && !Array.isArray(schema)) {
-    cb(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
+    pre(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
     for (var key in schema) {
       var sch = schema[key];
       if (Array.isArray(sch)) {
         if (key in traverse.arrayKeywords) {
           for (var i=0; i<sch.length; i++)
-            _traverse(opts, cb, sch[i], jsonPtr + '/' + key + '/' + i, rootSchema, jsonPtr, key, schema, i);
+            _traverse(opts, pre, post, sch[i], jsonPtr + '/' + key + '/' + i, rootSchema, jsonPtr, key, schema, i);
         }
       } else if (key in traverse.propsKeywords) {
         if (sch && typeof sch == 'object') {
           for (var prop in sch)
-            _traverse(opts, cb, sch[prop], jsonPtr + '/' + key + '/' + escapeJsonPtr(prop), rootSchema, jsonPtr, key, schema, prop);
+            _traverse(opts, pre, post, sch[prop], jsonPtr + '/' + key + '/' + escapeJsonPtr(prop), rootSchema, jsonPtr, key, schema, prop);
         }
       } else if (key in traverse.keywords || (opts.allKeys && !(key in traverse.skipKeywords))) {
-        _traverse(opts, cb, sch, jsonPtr + '/' + key, rootSchema, jsonPtr, key, schema);
+        _traverse(opts, pre, post, sch, jsonPtr + '/' + key, rootSchema, jsonPtr, key, schema);
       }
     }
+    post(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ var traverse = module.exports = function (schema, opts, cb) {
     opts = {};
   }
 
-  var pre = opts.pre || cb || function() {};
-  var post = opts.post || function() {};
+  cb = opts.cb || cb;
+  var pre = (typeof cb == 'function') ? cb : cb.pre || function() {};
+  var post = cb.post || function() {};
 
   _traverse(opts, pre, post, schema, '', schema);
 };

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -14,8 +14,27 @@ describe('json-schema-traverse', function() {
     var schema = require('./fixtures/schema').schema;
     var expectedCalls = require('./fixtures/schema').expectedCalls;
 
-    traverse(schema, callback);
+    traverse(schema, {pre: callback});
     assert.deepStrictEqual(calls, expectedCalls);
+  });
+
+  describe('Legacy v0.3.1 API', function() {
+    it('should traverse all keywords containing schemas recursively', function() {
+      var schema = require('./fixtures/schema').schema;
+      var expectedCalls = require('./fixtures/schema').expectedCalls;
+
+      traverse(schema, callback);
+      assert.deepStrictEqual(calls, expectedCalls);
+    });
+
+    it('should work when an options object is provided', function() {
+      // schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex
+      var schema = require('./fixtures/schema').schema;
+      var expectedCalls = require('./fixtures/schema').expectedCalls;
+
+      traverse(schema, {}, callback);
+      assert.deepStrictEqual(calls, expectedCalls);
+    });
   });
 
 
@@ -95,6 +114,47 @@ describe('json-schema-traverse', function() {
     });
   });
 
+  describe('pre and post', function() {
+    var schema;
+
+    beforeEach(function() {
+      schema = {
+        type: 'object',
+        properties: {
+          name: {type: 'string'}
+        }
+      };
+    });
+
+    function pre(child) {
+      child.preTraversed = true;
+      if(child.type === 'string')
+        // In the child object.
+        assert(schema.preTraversed, 'Should traverse parents before children');
+    }
+
+    function post(child) {
+      child.postTraversed = true;
+      if(child.type === 'string')
+        // In the child object.
+        assert(!schema.postTraversed, 'Should traverse children before parents');
+    }
+
+    it('should traverse schema in pre-order', function() {
+      traverse(schema, {pre});
+      assert(schema.preTraversed, 'Should travese the schema');
+    });
+
+    it('should traverse schema in post-order', function() {
+      traverse(schema, {post});
+      assert(schema.postTraversed, 'Should travese the schema');
+    });
+
+    it('should traverse schema in pre- and post-order at the same time', function() {
+      traverse(schema, {pre, post});
+      assert(schema.preTraversed && schema.postTraversed, 'Should travese the schema');
+    });
+  });
 
   function callback() {
     calls.push(Array.prototype.slice.call(arguments));

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -14,7 +14,7 @@ describe('json-schema-traverse', function() {
     var schema = require('./fixtures/schema').schema;
     var expectedCalls = require('./fixtures/schema').expectedCalls;
 
-    traverse(schema, {pre: callback});
+    traverse(schema, {cb: callback});
     assert.deepStrictEqual(calls, expectedCalls);
   });
 
@@ -53,7 +53,7 @@ describe('json-schema-traverse', function() {
         [schema.someObject, '/someObject', schema, '', 'someObject', schema, undefined]
       ];
 
-      traverse(schema, {allKeys: true}, callback);
+      traverse(schema, {allKeys: true, cb: callback});
       assert.deepStrictEqual(calls, expectedCalls);
     });
 
@@ -64,7 +64,7 @@ describe('json-schema-traverse', function() {
         [schema, '', schema, undefined, undefined, undefined, undefined]
       ];
 
-      traverse(schema, {allKeys: false}, callback);
+      traverse(schema, {allKeys: false, cb: callback});
       assert.deepStrictEqual(calls, expectedCalls);
     });
 
@@ -75,7 +75,7 @@ describe('json-schema-traverse', function() {
         [schema, '', schema, undefined, undefined, undefined, undefined]
       ];
 
-      traverse(schema, callback);
+      traverse(schema, {cb: callback});
       assert.deepStrictEqual(calls, expectedCalls);
     });
 
@@ -109,7 +109,7 @@ describe('json-schema-traverse', function() {
         [schema2.properties.larger, '/properties/larger', schema2, '', 'properties', schema2, 'larger'],
       ];
 
-      traverse(schema2, {allKeys: true}, callback);
+      traverse(schema2, {allKeys: true, cb: callback});
       assert.deepStrictEqual(calls, expectedCalls);
     });
   });
@@ -141,17 +141,17 @@ describe('json-schema-traverse', function() {
     }
 
     it('should traverse schema in pre-order', function() {
-      traverse(schema, {pre});
+      traverse(schema, {cb: {pre}});
       assert(schema.preTraversed, 'Should travese the schema');
     });
 
     it('should traverse schema in post-order', function() {
-      traverse(schema, {post});
+      traverse(schema, {cb: {post}});
       assert(schema.postTraversed, 'Should travese the schema');
     });
 
     it('should traverse schema in pre- and post-order at the same time', function() {
-      traverse(schema, {pre, post});
+      traverse(schema, {cb: {pre, post}});
       assert(schema.preTraversed && schema.postTraversed, 'Should travese the schema');
     });
   });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -115,17 +115,13 @@ describe('json-schema-traverse', function() {
   });
 
   describe('pre and post', function() {
-    var schema;
-
-    beforeEach(function() {
-      schema = {
-        type: 'object',
-        properties: {
-          name: {type: 'string'},
-          age: {type: 'number'}
-        }
-      };
-    });
+    var schema = {
+      type: 'object',
+      properties: {
+        name: {type: 'string'},
+        age: {type: 'number'}
+      }
+    };
 
     it('should traverse schema in pre-order', function() {
       traverse(schema, {cb: {pre}});

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -121,42 +121,55 @@ describe('json-schema-traverse', function() {
       schema = {
         type: 'object',
         properties: {
-          name: {type: 'string'}
+          name: {type: 'string'},
+          age: {type: 'number'}
         }
       };
     });
 
-    function pre(child) {
-      child.preTraversed = true;
-      if(child.type === 'string')
-        // In the child object.
-        assert(schema.preTraversed, 'Should traverse parents before children');
-    }
-
-    function post(child) {
-      child.postTraversed = true;
-      if(child.type === 'string')
-        // In the child object.
-        assert(!schema.postTraversed, 'Should traverse children before parents');
-    }
-
     it('should traverse schema in pre-order', function() {
       traverse(schema, {cb: {pre}});
-      assert(schema.preTraversed, 'Should travese the schema');
+      var expectedCalls = [
+        ['pre', schema, '', schema, undefined, undefined, undefined, undefined],
+        ['pre', schema.properties.name, '/properties/name', schema, '', 'properties', schema, 'name'],
+        ['pre', schema.properties.age, '/properties/age', schema, '', 'properties', schema, 'age'],
+      ];
+      assert.deepStrictEqual(calls, expectedCalls);
     });
 
     it('should traverse schema in post-order', function() {
       traverse(schema, {cb: {post}});
-      assert(schema.postTraversed, 'Should travese the schema');
+      var expectedCalls = [
+        ['post', schema.properties.name, '/properties/name', schema, '', 'properties', schema, 'name'],
+        ['post', schema.properties.age, '/properties/age', schema, '', 'properties', schema, 'age'],
+        ['post', schema, '', schema, undefined, undefined, undefined, undefined],
+      ];
+      assert.deepStrictEqual(calls, expectedCalls);
     });
 
     it('should traverse schema in pre- and post-order at the same time', function() {
       traverse(schema, {cb: {pre, post}});
-      assert(schema.preTraversed && schema.postTraversed, 'Should travese the schema');
+      var expectedCalls = [
+        ['pre', schema, '', schema, undefined, undefined, undefined, undefined],
+        ['pre', schema.properties.name, '/properties/name', schema, '', 'properties', schema, 'name'],
+        ['post', schema.properties.name, '/properties/name', schema, '', 'properties', schema, 'name'],
+        ['pre', schema.properties.age, '/properties/age', schema, '', 'properties', schema, 'age'],
+        ['post', schema.properties.age, '/properties/age', schema, '', 'properties', schema, 'age'],
+        ['post', schema, '', schema, undefined, undefined, undefined, undefined],
+      ];
+      assert.deepStrictEqual(calls, expectedCalls);
     });
   });
 
   function callback() {
     calls.push(Array.prototype.slice.call(arguments));
+  }
+
+  function pre() {
+    calls.push(['pre'].concat(Array.prototype.slice.call(arguments)));
+  }
+
+  function post() {
+    calls.push(['post'].concat(Array.prototype.slice.call(arguments)));
   }
 });


### PR DESCRIPTION
See #3.