### PR TITLE
Adding the conditional keywords to traverse

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ traverse.keywords = {
   additionalProperties: true,
   propertyNames: true,
   not: true,
+  if: true,
   then: true,
   else: true
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ traverse.keywords = {
   contains: true,
   additionalProperties: true,
   propertyNames: true,
-  not: true
+  not: true,
+  then: true,
+  else: true
 };
 
 traverse.arrayKeywords = {


### PR DESCRIPTION
Thanks for this module. Have had do do some custom schema traversing and came across that this module doesn't traverse into conditional schemas. I was able to get the expected behavior by adding `then` and `else` to the keywords.

I by all means don't expect this to be merged but wanted to put it forward. There may have been reasoning that I am not aware of to omit the conditional properties.

Thoughts?