### PR TITLE
Only publish required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Traverse JSON Schema passing each schema object to callback",
   "main": "index.js",
   "types": "index.d.ts",
+  "files":[],
   "scripts": {
     "eslint": "eslint index.js spec",
     "test-spec": "mocha spec -R spec",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Traverse JSON Schema passing each schema object to callback",
   "main": "index.js",
   "types": "index.d.ts",
-  "files":[],
+  "files":[
+    "index.d.ts"
+  ],
   "scripts": {
     "eslint": "eslint index.js spec",
     "test-spec": "mocha spec -R spec",


### PR DESCRIPTION
`.github`,`spec`, and `.eslintrc.yml` are currently shipping with the node modules. This should remove them.

--edit --
Wasn't able to find it in the npm docs, will `types` be white listed like `main`?

Also just saw https://github.com/epoberezkin/json-schema-traverse/pull/8, a duplicate, but might be outdated now.