### PR TITLE
feat(types): expand typings and add @ts-check

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,20 @@
+/**
+ * Traverse JSON Schema passing each schema object to callback
+ * @param schema
+ * @param opts
+ * @param [cb]
+ */
 declare function traverse(
   schema: traverse.SchemaObject,
   opts: traverse.Options,
   cb?: traverse.Callback
 ): void;
 
+/**
+ * Traverse JSON Schema passing each schema object to callback
+ * @param schema
+ * @param cb
+ */
 declare function traverse(
   schema: traverse.SchemaObject,
   cb: traverse.Callback
@@ -35,6 +46,54 @@ declare namespace traverse {
           post?: Callback;
         };
   }
+
+  type Keywords =
+    | "additionalItems"
+    | "additionalProperties"
+    | "contains"
+    | "else"
+    | "if"
+    | "items"
+    | "not"
+    | "propertyNames"
+    | "then";
+
+  type ArrayKeywords = "allOf" | "anyOf" | "items" | "oneOf";
+
+  type PropsKeywords =
+    | "$defs"
+    | "definitions"
+    | "dependencies"
+    | "patternProperties"
+    | "properties";
+
+  type SkipKeywords =
+    | "const"
+    | "default"
+    | "enum"
+    | "exclusiveMaximum"
+    | "exclusiveMinimum"
+    | "format"
+    | "maximum"
+    | "maxItems"
+    | "maxLength"
+    | "maxProperties"
+    | "minimum"
+    | "minItems"
+    | "minLength"
+    | "minProperties"
+    | "multipleOf"
+    | "pattern"
+    | "required"
+    | "uniqueItems";
+
+  const keywords: Record<Keywords, true>;
+
+  const arrayKeywords: Record<ArrayKeywords, true>;
+
+  const propsKeywords: Record<PropsKeywords, true>;
+
+  const skipKeywords: Record<SkipKeywords, true>;
 }
 
 export = traverse;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
+// @ts-check
 'use strict';
+
+/** @typedef {import("./").ArrayKeywords} ArrayKeywords */
+/** @typedef {import("./").Keywords} Keywords */
+/** @typedef {import("./").PropsKeywords} PropsKeywords */
+/** @typedef {import("./").SkipKeywords} SkipKeywords */
 
 var traverse = module.exports = function (schema, opts, cb) {
   // Legacy support for v0.3.1 and earlier.
@@ -6,7 +12,6 @@ var traverse = module.exports = function (schema, opts, cb) {
     cb = opts;
     opts = {};
   }
-
   cb = opts.cb || cb;
   var pre = (typeof cb == 'function') ? cb : cb.pre || function() {};
   var post = cb.post || function() {};
@@ -14,7 +19,7 @@ var traverse = module.exports = function (schema, opts, cb) {
   _traverse(opts, pre, post, schema, '', schema);
 };
 
-
+/** @type {Record<Keywords, true>} */
 traverse.keywords = {
   additionalItems: true,
   items: true,
@@ -27,6 +32,7 @@ traverse.keywords = {
   else: true
 };
 
+/** @type {Record<ArrayKeywords, true>} */
 traverse.arrayKeywords = {
   items: true,
   allOf: true,
@@ -34,6 +40,7 @@ traverse.arrayKeywords = {
   oneOf: true
 };
 
+/** @type {Record<PropsKeywords, true>} */
 traverse.propsKeywords = {
   $defs: true,
   definitions: true,
@@ -42,6 +49,7 @@ traverse.propsKeywords = {
   dependencies: true
 };
 
+/** @type {Record<SkipKeywords, true>} */
 traverse.skipKeywords = {
   default: true,
   enum: true,


### PR DESCRIPTION
- expands typings to define exported dictionaries
- use typings internally to type-check main file
- checks are optional (via @ts-check), but can be instrumented:

```bash
tsc --allowJs --noEmit ./index.js
```

I wrote a 0.4 typings while ago, which are now no longer required 👯 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50505

Thanks!

I think the rewrite to TS is no longer required for this package.

Closes #7